### PR TITLE
Fix Firebase config exposure and add security rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+firebase-config.js

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# yoontaePaper.github.io
+# Paper Management Assistant
+
+This project uses Firebase for authentication and data storage.
+
+## Setup
+
+1. Copy `firebase-config-example.js` to `firebase-config.js` and replace the placeholder values with your Firebase project credentials.
+   Keep `firebase-config.js` out of version control (see `.gitignore`).
+
+   ```bash
+   cp firebase-config-example.js firebase-config.js
+   ```
+
+2. Deploy the Firestore security rules in `firestore.rules` using the Firebase CLI:
+
+   ```bash
+   firebase deploy --only firestore:rules
+   ```
+
+   You can also test them locally with the emulator:
+
+   ```bash
+   firebase emulators:exec --project <project-id> "npm test"
+   ```

--- a/firebase-config-example.js
+++ b/firebase-config-example.js
@@ -1,0 +1,13 @@
+// Copy this file to `firebase-config.js` and replace the placeholders
+// with your Firebase project credentials. Keep `firebase-config.js`
+// out of version control.
+
+window.__firebase_config = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID",
+  measurementId: "YOUR_MEASUREMENT_ID"
+};

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,55 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    /* 1) 기본은 전부 거부 */
+    match /{document=**} {
+      allow read, write: if false;
+    }
+
+    /* 2) 공통 헬퍼 */
+    function isSignedIn()      { return request.auth != null; }
+    function isOwner(uid)      { return request.auth.uid == uid; }
+
+    /* 논문(paper) 스키마 검증 함수 */
+    function validPaper(data) {
+      return data.keys().hasAll(['title', 'tags', 'status', 'importance'])
+          && data.title is string && data.title.size() > 0
+          && data.tags  is string && data.tags.size()  > 0
+          && data.status in ['To Read', 'Reading', 'Finished']
+          && data.importance is int
+          && data.importance >= 1 && data.importance <= 5
+          && (!('year' in data)
+              || (data.year is int && data.year >= 1900 && data.year <= 2100));
+    }
+
+    /* 3) artifacts 루트 */
+    match /artifacts/{appId}/users/{userId} {
+
+      /* 3‑1) papers 컬렉션 */
+      match /papers/{paperId} {
+
+        // 읽기
+        allow get, list: if isSignedIn() && isOwner(userId);
+
+        // 생성
+        allow create: if isSignedIn()
+                       && isOwner(userId)
+                       && validPaper(request.resource.data);
+
+        // 수정
+        allow update: if isSignedIn()
+                       && isOwner(userId)
+                       && validPaper(request.resource.data);
+
+        // 삭제
+        allow delete: if isSignedIn() && isOwner(userId);
+
+        /* 3‑2) memos 서브컬렉션 */
+        match /memos/{memoId} {
+          allow read, write: if isSignedIn() && isOwner(userId);
+        }
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
     </div>
 
 
+    <script src="firebase-config.js"></script>
     <script type="module">
         // Firebase SDK imports
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-app.js";
@@ -326,19 +327,11 @@
             setLogLevel
         } from "https://www.gstatic.com/firebasejs/11.6.1/firebase-firestore.js";
 
-        // Firebase configuration
-        const firebaseConfig = typeof __firebase_config !== 'undefined'
-            ? JSON.parse(__firebase_config)
-            : {
-                // Fallback config, in case the environment variable is not set.
-                apiKey: "AIzaSyCfn0BpuqPHN9ynZ6BiGEoOBgaif7FO690",
-                authDomain: "paper-saver-df418.firebaseapp.com",
-                projectId: "paper-saver-df418",
-                storageBucket: "paper-saver-df418.firebasestorage.app",
-                messagingSenderId: "23245752480",
-                appId: "1:23245752480:web:48d71705302c2b703ea1c5",
-                measurementId: "G-TL12FY1091"
-            };
+        // Firebase configuration loaded from `firebase-config.js`
+        if (typeof window.__firebase_config === 'undefined') {
+            throw new Error('Firebase configuration not found. Please create `firebase-config.js` based on `firebase-config-example.js`.');
+        }
+        const firebaseConfig = window.__firebase_config;
         
         // Initialize Firebase
         const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
## Summary
- prevent leaking Firebase API keys by loading configuration from an ignored `firebase-config.js`
- document how to create the config file and deploy security rules
- include example Firestore rules

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68891221b5408331a8d3f72cf57b6169